### PR TITLE
Resolve crashpad permission error

### DIFF
--- a/lib/chrome_launcher.ex
+++ b/lib/chrome_launcher.ex
@@ -76,8 +76,11 @@ defmodule ChromeLauncher do
   end
 
   defp formatted_flags(opts) do
+    tmp_dir = System.tmp_dir()
+
     internal_flags = [
       "--remote-debugging-port=#{opts[:remote_debugging_port]}",
+      "--crash-dumps-dir=#{tmp_dir}"
     ]
 
     (internal_flags ++ List.wrap(opts[:flags]))


### PR DESCRIPTION
When using headless, if the launching OS process doesn't have permission
in the directory that Chrome is found in the crashpad reporter will
attempt to `mkdir` and error out. This did not prevent Chrome from
launching, it would just continuously log out and be noisy.

This PR addresses this by setting the crash dump directory to a tmp one
that is writable by the launching process.

This flag I believe is only necessary on `darwin` and should be ignored
on other OSes