### PR TITLE
Add `child_spec/1` for usage in Supervisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,40 @@ Only supports OSX + Linux at this time.
 ])
 ```
 
+> Or in a supervisor (1.5+)
+
+```elixir
+children = [
+  {ChromeLauncher, [remote_debugging_port: 9222]}
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+> With multiple instances in a supervisor (1.5+)
+
+```elixir
+children = [
+  Supervisor.child_spec({ChromeLauncher, [remote_debugging_port: 9222]}, id: :chrome_1),
+  Supervisor.child_spec({ChromeLauncher, [remote_debugging_port: 9223]}, id: :chrome_2),
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+> Pre 1.5
+
+```elixir
+import Supervisor.Spec
+
+children = [
+  worker(ChromeLauncher, [[remote_debugging_port: 9222]], id: :chrome_1),
+  worker(ChromeLauncher, [[remote_debugging_port: 9223]], id: :chrome_2),
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
 Available options:
 
 - `remote_debugging_port`: Configures `--remote-debugging-port=PORT` flag for connecting to the chrome process.

--- a/lib/chrome_launcher.ex
+++ b/lib/chrome_launcher.ex
@@ -80,10 +80,12 @@ defmodule ChromeLauncher do
   end
   defp await_process_on_port(os_pid, port, retries_left) do
     case :gen_tcp.connect('localhost', port, []) do
-      {:error, _} ->
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+        {:ok, os_pid}
+      _ ->
         Process.sleep(30)
         await_process_on_port(os_pid, port, retries_left - 1)
-      _ -> {:ok, os_pid}
     end
   end
 

--- a/lib/chrome_launcher.ex
+++ b/lib/chrome_launcher.ex
@@ -5,6 +5,18 @@ defmodule ChromeLauncher do
 
   require Logger
 
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      shutdown: 5000,
+      type: :worker
+    }
+  end
+
+  def start_link(opts \\ []), do: launch(opts)
+
   @doc """
   Launches an instance of Chrome.
   """


### PR DESCRIPTION
Implements https://github.com/andrewvy/chrome-launcher/issues/10.

This would allow easier specification as a worker and adds the generic `start_link/1` function.

> In a supervisor (1.5+)

```elixir
children = [
  {ChromeLauncher, [remote_debugging_port: 9222]}
]

Supervisor.start_link(children, strategy: :one_for_one)
```

> With multiple instances in a supervisor (1.5+)

```elixir
children = [
  Supervisor.child_spec({ChromeLauncher, [remote_debugging_port: 9222]}, id: :chrome_1),
  Supervisor.child_spec({ChromeLauncher, [remote_debugging_port: 9223]}, id: :chrome_2),
]

Supervisor.start_link(children, strategy: :one_for_one)
```

> Pre 1.5

```elixir
import Supervisor.Spec

children = [
  worker(ChromeLauncher, [[remote_debugging_port: 9222]], id: :chrome_1),
  worker(ChromeLauncher, [[remote_debugging_port: 9223]], id: :chrome_2),
]

Supervisor.start_link(children, strategy: :one_for_one)
```

---

Having the `pids` of the actual exec processes isn't too useful, so the user will have to track the ports used by each child in order to connect to them.