### PR TITLE
Wait for chrome to launch via stderr

### DIFF
--- a/lib/chrome_launcher.ex
+++ b/lib/chrome_launcher.ex
@@ -35,7 +35,7 @@ defmodule ChromeLauncher do
           end,
           stderr: fn(_, pid, data) ->
             if !Process.get(:chrome_launched, false) && :binary.match(data, "DevTools listening on ws://") do
-              send(parent, :chrome_launched)
+              send(parent, {:chrome_launched, pid})
               Process.put(:chrome_launched, true)
             end
 
@@ -78,7 +78,7 @@ defmodule ChromeLauncher do
 
   defp wait_for_chrome_to_launch(os_pid) do
     receive do
-      :chrome_launched ->
+      {:chrome_launched, ^os_pid} ->
         {:ok, os_pid}
     after
       10_000 ->

--- a/lib/chrome_launcher.ex
+++ b/lib/chrome_launcher.ex
@@ -34,7 +34,7 @@ defmodule ChromeLauncher do
             Logger.info("[#{pid}] #{inspect(data)}")
           end,
           stderr: fn(_, pid, data) ->
-            if !Process.get(:chrome_launched, false) && :binary.match(data, "DevTools listening on ws://") do
+            if !Process.get(:chrome_launched, false) && (:binary.match(data, "DevTools listening on ws://") != :nomatch) do
               send(parent, {:chrome_launched, pid})
               Process.put(:chrome_launched, true)
             end


### PR DESCRIPTION
A quick implementation of the first option from #8 just for investigating possibilities. May or may not be the true solution. 😄 

This replaces the polling of the chrome instance by instead scanning the stderr logs of the `exec`'d Chrome Instance for a `DevTools listening on ws://` message.

Some points:

- Questionable use of the process dictionary to not run a `:binary.match` on every single stderr message.
- May leak messages if `exec`'d process sends the launch message just as the timeout occurs