### PR TITLE
Parse stderr for dynamic logging levels

### DIFF
--- a/lib/chrome_launcher.ex
+++ b/lib/chrome_launcher.ex
@@ -30,16 +30,16 @@ defmodule ChromeLauncher do
         parent = self()
 
         exec_opts = [
-          stdout: fn(_, pid, data) ->
-            Logger.info("[#{pid}] #{inspect(data)}")
+          stdout: fn(_, _, data) ->
+            Logger.info(data)
           end,
           stderr: fn(_, pid, data) ->
-            if !Process.get(:chrome_launched, false) && (:binary.match(data, "DevTools listening on ws://") != :nomatch) do
+            if !Process.get(:chrome_launched, false) && (:binary.match(data, "DevTools listening on") != :nomatch) do
               send(parent, {:chrome_launched, pid})
               Process.put(:chrome_launched, true)
+            else
+              ChromeLauncher.Logger.log(data)
             end
-
-            Logger.error("[#{pid}] #{inspect(data)}")
           end
         ]
 

--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -1,0 +1,22 @@
+defmodule ChromeLauncher.Logger do
+  @moduledoc """
+  This module is responsible for parsing logging out of chrome
+  instances and output logging at the correct levels.
+  """
+
+  require Logger
+
+  def log(binary) do
+    log_level = determine_log_level(binary)
+
+    Logger.bare_log(log_level, binary)
+  end
+
+  def determine_log_level(binary) do
+    cond do
+      :binary.match(binary, ":INFO:") != :nomatch -> :info
+      :binary.match(binary, ":WARNING:") != :nomatch -> :warn
+      true -> :error
+    end
+  end
+end


### PR DESCRIPTION
Implements https://github.com/andrewvy/chrome-launcher/issues/13.

All output from the headless chrome instance is over stderr, regardless of what logging level it is. This PR attempts to parse the log message to get the correct logging level for `Logger`.